### PR TITLE
[ci] Disable check-publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,17 +93,17 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  check-publish:
-    name: publish dry run
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --dry-run
+  # check-publish:
+  #   name: publish dry run
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: stable
+  #         override: true
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         command: publish
+  #         args: --dry-run


### PR DESCRIPTION
According to [this message](https://github.com/paritytech/ci_cd/issues/826#issuecomment-1686863102) the job should be disabled. I'm commenting it if there is need in the future for it.

Close https://github.com/paritytech/ci_cd/issues/826